### PR TITLE
Epics in the roadmap repository should not contain customer names if …

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -58,10 +58,6 @@ _Please remove non-applicable items_
 
 _Please link issues/epics here which have to be solved before_
 
-## Customers driving/requiring this
-
-_Please add customer names, if applicable._
-
 ## Timeline
 
 _Please add info regarding deadlines/timelines, if available._


### PR DESCRIPTION
…we want to make them public. 
I just notices that the epic template is querying for customer names that are interested / needing the feature. As we don't want to have the customer names in this repo I suggest we remove this section from the template.  