### PR TITLE
remove g8s

### DIFF
--- a/.github/ISSUE_TEMPLATE/gs-release.md
+++ b/.github/ISSUE_TEMPLATE/gs-release.md
@@ -1,6 +1,6 @@
 ---
-name: G8s Release
-about: Template for a to-do issue to track a new g8s release
+name: Giant Swarm Tenant Cluster Release
+about: Template for a to-do issue to track a new Giant Swarm Tenant Cluster release
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/9984

TLDR: g8s was an internal codename years ago, and we need to get rid of it ;)

