### PR TITLE
Modify app upgrade template

### DIFF
--- a/.github/ISSUE_TEMPLATE/upgrade_apps.md
+++ b/.github/ISSUE_TEMPLATE/upgrade_apps.md
@@ -72,6 +72,8 @@ https://github.com/giantswarm/aqua-app
 * Link to latest release: 
 * If won't upgrade, why? @jgsqware or @yasn77 we'll skip checking for any upgrades unless you tell us to.
 
+---
+
 Notes
 * Team divides the app upgrades amongst ourselves. Please add @ name beside the app
 * [30 Day Upgrade Promise](https://intranet.giantswarm.io/docs/product/pdr/003_30-day-upgrade-promise/): By default, we upgrade our apps within 30 days of an upstream release. We know that falling behind releases and putting upgrades off for extended amounts of time, especially when there’s breaking changes, almost always comes back to bite us.

--- a/.github/ISSUE_TEMPLATE/upgrade_apps.md
+++ b/.github/ISSUE_TEMPLATE/upgrade_apps.md
@@ -54,7 +54,7 @@ https://github.com/giantswarm/kong-app
 - [ ] upgrade
 - [ ] release
 
-**Prometheus Operator** @giantswarm/app-squad-prometheus
+**Prometheus Operator** @giantswarm/app-squad-prometheus  
 https://github.com/giantswarm/prometheus-operator-app
 
 * Link to latest release: 

--- a/.github/ISSUE_TEMPLATE/upgrade_apps.md
+++ b/.github/ISSUE_TEMPLATE/upgrade_apps.md
@@ -1,37 +1,75 @@
 ---
 name: Upgrade Apps
 about: Create issue to upgrade Managed Apps
-title: Managed Apps Upgrades (Week of {enter date})
+title: Managed Apps Upgrades (Month of {enter date})
 labels: team/halo, kind/upgrade
 assignees: ''
 
 ---
 
-Apps to either be upgraded or decided not to upgrade by Friday this week:
+Aim to focus on 30DU and get them done within 2 days.
 
-- [ ] [nginx ic](https://github.com/giantswarm/nginx-ingress-controller-app) @
+**NGINX Ingress Controller** @giantswarm/app-squad-nginx
+https://github.com/giantswarm/nginx-ingress-controller-app
+
 * Link to latest release: 
 * If won't upgrade, why?
 
-- [ ] [kong](https://github.com/giantswarm/kong-app) @
+- [ ] upgrade
+- [ ] release
+
+**External DNS** @giantswarm/app-squad-external-dns
+https://github.com/giantswarm/external-dns-app
+
 * Link to latest release: 
 * If won't upgrade, why?
 
-- [ ] [efk-stack-app](https://github.com/giantswarm/efk-stack-app/) @webwurst 
+- [ ] upgrade
+- [ ] release
+
+**Cert Manager** @giantswarm/app-squad-cert-manager
+https://github.com/giantswarm/cert-manager-app
+
 * Link to latest release: 
 * If won't upgrade, why?
 
-- [ ] [aqua](https://github.com/giantswarm/aqua-app) @
+- [ ] upgrade
+- [ ] release
+
+**EFK** @giantswarm/app-squad-efk
+https://github.com/giantswarm/efk-stack-app
+
 * Link to latest release: 
 * If won't upgrade, why?
 
-- [ ] [cert-manager](https://github.com/giantswarm/cert-manager-app) @
+- [ ] upgrade
+- [ ] release
+
+**Kong** @giantswarm/app-squad-kong
+
 * Link to latest release: 
 * If won't upgrade, why?
 
-- [ ] [external-dns](https://github.com/giantswarm/external-dns-app) @
+- [ ] upgrade
+- [ ] release
+
+**Prometheus Operator** @giantswarm/app-squad-prometheus
+https://github.com/giantswarm/prometheus-operator-app
+
 * Link to latest release: 
 * If won't upgrade, why?
+
+- [ ] upgrade
+- [ ] release
+
+**~~aqua~~**
+https://github.com/giantswarm/aqua-app
+
+- [ ] ~~upgrade~~
+- [ ] ~~release~~
+
+* Link to latest release: 
+* If won't upgrade, why? @jgsqware or @yasn77 we'll skip checking for any upgrades unless you tell us to.
 
 Notes
 * Team divides the app upgrades amongst ourselves. Please add @ name beside the app

--- a/.github/ISSUE_TEMPLATE/upgrade_apps.md
+++ b/.github/ISSUE_TEMPLATE/upgrade_apps.md
@@ -9,7 +9,7 @@ assignees: ''
 
 Aim to focus on 30DU and get them done within 2 days.
 
-**NGINX Ingress Controller** @giantswarm/app-squad-nginx
+**NGINX Ingress Controller** @giantswarm/app-squad-nginx  
 https://github.com/giantswarm/nginx-ingress-controller-app
 
 * Link to latest release: 
@@ -18,7 +18,7 @@ https://github.com/giantswarm/nginx-ingress-controller-app
 - [ ] upgrade
 - [ ] release
 
-**External DNS** @giantswarm/app-squad-external-dns
+**External DNS** @giantswarm/app-squad-external-dns  
 https://github.com/giantswarm/external-dns-app
 
 * Link to latest release: 
@@ -27,7 +27,7 @@ https://github.com/giantswarm/external-dns-app
 - [ ] upgrade
 - [ ] release
 
-**Cert Manager** @giantswarm/app-squad-cert-manager
+**Cert Manager** @giantswarm/app-squad-cert-manager  
 https://github.com/giantswarm/cert-manager-app
 
 * Link to latest release: 
@@ -36,7 +36,7 @@ https://github.com/giantswarm/cert-manager-app
 - [ ] upgrade
 - [ ] release
 
-**EFK** @giantswarm/app-squad-efk
+**EFK** @giantswarm/app-squad-efk  
 https://github.com/giantswarm/efk-stack-app
 
 * Link to latest release: 
@@ -45,7 +45,8 @@ https://github.com/giantswarm/efk-stack-app
 - [ ] upgrade
 - [ ] release
 
-**Kong** @giantswarm/app-squad-kong
+**Kong** @giantswarm/app-squad-kong  
+https://github.com/giantswarm/kong-app
 
 * Link to latest release: 
 * If won't upgrade, why?
@@ -62,8 +63,8 @@ https://github.com/giantswarm/prometheus-operator-app
 - [ ] upgrade
 - [ ] release
 
-**~~aqua~~**
-https://github.com/giantswarm/aqua-app
+**~~aqua~~**  
+https://github.com/giantswarm/aqua-app  
 
 - [ ] ~~upgrade~~
 - [ ] ~~release~~


### PR DESCRIPTION
Modify 30DU App Upgrade template.

I want to create it by default in public roadmap.
1. Add prometheus operator
2. Ping apps quads
3. Link to repos
4. Create checkboxes for upgrade and release
5. Add reminder we want to focus and get them done within 2 days