### PR TITLE
Add Phoenix to label automations

### DIFF
--- a/.github/workflows/project-labels.yaml
+++ b/.github/workflows/project-labels.yaml
@@ -31,8 +31,7 @@ jobs:
         GS_FEATUREREQUEST: feature-request,534325       # Product Board Inbox
         GS_TEAM_ATLAS: team/atlas,8912071               # Team Atlas Inbox
         GS_TEAM_RAINBOW: team/rainbow,16167142          # Team Rainbow Inbox
-        GS_TEAM_CELESTIAL: team/celestial,6027800       # Team Celestial Inbox
-        GS_TEAM_FIRECRACKER: team/firecracker,1526481   # Team Firecracker Inbox
+        GS_TEAM_PHOENIX: team/phoenix,16425979          # Team Phoenix Inbox
         GS_TEAM_HALO: team/halo,7288839                 # Team Halo Inbox
         GS_TEAM_HONEYBADGER: team/honeybadger,16200567  # Team Honeybadger Inbox
         GS_TEAM_ROCKET: team/rocket,8122274             # Team Rocket Inbox


### PR DESCRIPTION
Removing Celestial & Firecracker

@giantswarm/team-phoenix 