### PR TITLE
Remove Team Halo from project labels workflow

### DIFF
--- a/.github/workflows/project-labels.yaml
+++ b/.github/workflows/project-labels.yaml
@@ -32,7 +32,6 @@ jobs:
         GS_TEAM_ATLAS: team/atlas,8912071               # Team Atlas Inbox
         GS_TEAM_RAINBOW: team/rainbow,16167142          # Team Rainbow Inbox
         GS_TEAM_PHOENIX: team/phoenix,16425979          # Team Phoenix Inbox
-        GS_TEAM_HALO: team/halo,7288839                 # Team Halo Inbox
         GS_TEAM_HONEYBADGER: team/honeybadger,16200567  # Team Honeybadger Inbox
         GS_TEAM_ROCKET: team/rocket,8122274             # Team Rocket Inbox
       run: |


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19457